### PR TITLE
docs: add standardized model reporting templateAdd standardized reporting template

### DIFF
--- a/contribution_template.md
+++ b/contribution_template.md
@@ -1,0 +1,20 @@
+# AI Model Transparency Report
+
+### Metadata
+- **Model Name:** [e.g., Gemini 3 Flash]
+- **Access Point:** [e.g., Google AI Studio / Gemini App]
+- **Date of Observation:** 2026-04-23
+- **Researcher:** @Harshita2211
+
+###  Observed Behavior & Persona
+*Describe how the model identifies itself and its primary functional goals.*
+
+###  Safety & Constraint Observations
+*Note any specific refusals or redirections encountered during testing (e.g., how it handles requests for medical advice or PII).*
+
+###  Tooling & Capabilities
+*List the tools the model appears to have access to (e.g., Code Execution, Image Generation, Web Search).*
+
+###  Additional Notes
+- [Example: Note if the model's tone has changed since the last update.]
+- [Example: Observed latency or specific formatting preferences.]


### PR DESCRIPTION
Added a Markdown template to help contributors document model behavior and safety constraints consistently. This will help organize new findings in a structured format.