### PR TITLE
feat: add Chinese README (README-cn.md)

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -1,0 +1,80 @@
+# CL4R1T4S
+
+**AI 系统透明度与可观测性 —— 面向所有人！**
+
+完整提取的系统提示词、指南和工具，涵盖 OpenAI、Google、Anthropic、xAI、Perplexity、Cursor、Windsurf、Devin、Manus、Replit 等 —— 几乎所有主流 AI 模型和 Agent！
+
+[English](./README.md) | 中文
+
+---
+
+## 📌 为什么要做这个
+
+> "要信任输出，必须先理解输入。"
+
+AI 实验室通过庞大的、不可见的提示词框架来塑造模型的行为。由于 AI 正在成为越来越多人信赖的外部智能层，这些隐藏的指令会影响公众的认知和行为。
+
+这些提示词定义了：
+
+- AI 不能说什么
+- AI 被迫扮演的角色和执行的功能
+- AI 被告知如何拒绝、撒谎或转移话题
+- 默认嵌入的伦理/政治框架
+
+**如果你在不了解系统提示词的情况下与 AI 对话，你不是在和一个中立的智能体交流 —— 你是在和一个"影子木偶"对话。**
+
+CL4R1T4S 就是为了改变这一切。
+
+---
+
+## 📂 目录结构
+
+项目按厂商/产品分类，每个目录下包含该产品的系统提示词文件：
+
+| 目录 | 涵盖产品 |
+|------|----------|
+| `ANTHROPIC/` | Claude 系列（3.5、4、4.1、4.5 Opus、Sonnet 3.7/4.6/4.7）、Claude Code、Claude Design |
+| `OPENAI/` | ChatGPT（4o、4.1、5、o3/o4-mini）、GPT-4.5、Codex、Atlas、ChatKit |
+| `XAI/` | Grok 3、Grok 4（多版本）、Grok-Code-Fast-1 |
+| `GOOGLE/` | Gemini 2.5 Pro、Gemini Diffusion、Gemini Gmail Assistant |
+| `CURSOR/` | Cursor 2.0、Cursor Prompt、Cursor Tools |
+| `DEVIN/` | Devin 2.0（多版本）、Devin Commands |
+| `REPLIT/` | Replit Agent、Replit Functions |
+| `WINDSURF/` | Windsurf Prompt、Windsurf Tools |
+| `MANUS/` | Manus Prompt、Manus Functions |
+| `META/` | Llama4 WhatsApp、Muse Spark |
+| `MOONSHOT/` | Kimi 2、Kimi K2 Thinking |
+| 其他 | Bolt、Cline、Lovable、Vercel v0、Perplexity、MiniMax、Mistral 等 |
+
+共涵盖 **24+ 厂商**，**60+ 个系统提示词文件**。
+
+---
+
+## 🛠 如何贡献
+
+提取或逆向工程到了系统提示词？太好了！
+
+通过 Pull Request 提交，需包含：
+
+- ✅ 模型名称/版本
+- 🗓 提取日期（如已知）
+- 🧾 上下文/备注（可选但有帮助）
+
+或在 X (Twitter) / Discord 上联系 @elder_plinius
+
+---
+
+## 📜 许可证
+
+本项目采用 [GNU AGPL v3](./LICENSE) 开源许可证。
+
+---
+
+## 🔗 相关链接
+
+- [原项目 GitHub](https://github.com/elder-plinius/CL4R1T4S)
+- 维护者：[@elder_plinius](https://x.com/elder_plinius)
+
+---
+
+*<.-.-.-.-{Love, Pliny <3}-.-.-.-.>*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CL4R1T4S
 
-English | [中文](./README-cn.md)
+[English](./README.md) | [中文](./README-cn.md)
 
 AI SYSTEMS TRANSPARENCY AND OBSERVABILITY FOR ALL! Full extracted system prompts, guidelines, and tools from OpenAI, Google, Anthropic, xAI, Perplexity, Cursor, Windsurf, Devin, Manus, Replit, and more – virtually all major AI models + agents! 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CL4R1T4S
 
+English | [中文](./README-cn.md)
+
 AI SYSTEMS TRANSPARENCY AND OBSERVABILITY FOR ALL! Full extracted system prompts, guidelines, and tools from OpenAI, Google, Anthropic, xAI, Perplexity, Cursor, Windsurf, Devin, Manus, Replit, and more – virtually all major AI models + agents! 
 
 📌 Why This Exists


### PR DESCRIPTION
## Summary

- Add README-cn.md - complete Chinese translation of the project README
- Add language switch links in both README files for easy navigation
- Include a detailed directory structure table (not in the original README)

## Why

This project's mission is **AI transparency for ALL**. Adding a Chinese README helps reach the massive Chinese-speaking AI research and development community, aligning with the project's core goal of making AI systems more transparent and accessible.

## Changes

1. **README-cn.md** (new): Full Chinese translation covering:
   - Project purpose and motivation
   - Detailed directory structure with product descriptions
   - Contribution guidelines
   - License information

2. **README.md** (modified): Added language switch link English | [中文](./README-cn.md) at the top

## Notes

- Translation preserves the original meaning and tone
- Added directory structure table to help Chinese users quickly understand the project layout
- Both files cross-link to each other for easy language switching