### PR TITLE
Add Tura v0.1.33 system prompt map

### DIFF
--- a/TURA/Tura_v0.1.33_System_Prompt_Map.md
+++ b/TURA/Tura_v0.1.33_System_Prompt_Map.md
@@ -1,0 +1,56 @@
+# Tura v0.1.33 system prompt map
+
+- Project: https://github.com/Tura-AI/tura
+- Release: https://github.com/Tura-AI/tura/releases/tag/v0.1.33
+- Release date: 2026-07-14
+- Prompt architecture: https://github.com/Tura-AI/tura/blob/v0.1.33/docs/core/prompt-style.md
+- Extraction method: version-pinned mapping of the public runtime sources
+
+Tura does not use one static mega-prompt. At runtime, it composes several system
+messages from the selected agent, frontend, persona, task type, session state,
+and context pressure. It supplies the available tool catalog separately as
+runtime capabilities. Its first runtime-owned identity message is generated
+from this template:
+
+```text
+You are {agent}, an agent. Current user: {user}. Runtime model: {model}. LLM
+provider: {provider}. Active context limit before compaction: {context_limit}
+tokens. {language_instruction} Follow the persona and agent instructions
+supplied in the following system messages.
+```
+
+Identity source:
+
+https://github.com/Tura-AI/tura/blob/v0.1.33/crates/runtime/src/prompt_style/agent_identity.rs
+
+## Agent behavior
+
+- Balanced:
+  https://github.com/Tura-AI/tura/blob/v0.1.33/agents/src/balanced/prompt.md
+- Direct:
+  https://github.com/Tura-AI/tura/blob/v0.1.33/agents/src/direct/prompt.md
+- Direct text-only:
+  https://github.com/Tura-AI/tura/blob/v0.1.33/agents/src/direct-text-only/prompt.md
+
+## Tool and capability sources
+
+- apply_patch, bash, planning, shell_command, task_status, and zsh:
+  https://github.com/Tura-AI/tura/tree/v0.1.33/crates/tools/src/commands
+
+## Task-specific operation manuals
+
+- Data research, debugging, DevOps, editorial, frontend, interactive/3D,
+  new-build, refactoring, visual, and website prompts:
+  https://github.com/Tura-AI/tura/tree/v0.1.33/crates/runtime/src/runtime_prompt
+
+## Runtime assembly
+
+- Turn assembly and conditional tail prompts:
+  https://github.com/Tura-AI/tura/blob/v0.1.33/crates/runtime/src/manas/runtime_turn.rs
+- Agent/persona prompt loading:
+  https://github.com/Tura-AI/tura/blob/v0.1.33/crates/runtime/src/manas/agent_prompts.rs
+- Context reconstruction:
+  https://github.com/Tura-AI/tura/blob/v0.1.33/crates/runtime/src/context/build.rs
+
+The linked Tura source remains licensed under AGPL-3.0-or-later. This file is a
+version-pinned source map and does not relicense the linked prompt files.


### PR DESCRIPTION
## Summary

- Add a version-pinned source map for Tura v0.1.33.
- Explain that Tura composes several system messages dynamically instead of using one static mega-prompt.
- Link the public identity template, agent prompts, tool definitions, task manuals, and runtime assembly sources.
- Preserve the linked source's AGPL-3.0-or-later licensing context.

The repository asks for model or agent system prompts, guidelines, and tools. This file documents Tura's directly verifiable public prompt sources without presenting them as a leak or fabricating a single static prompt that the runtime does not have.

## Verification

- All 12 project, release, prompt, tool, and runtime links return HTTP 200.
- `git diff --check` passes.
- Repository code plus GitHub Issue and PR searches found no existing Tura entry or submission.

## Disclosure

I am affiliated with the Tura project and am submitting this source map on its behalf.

AI assistance was used to research the contribution rules, prepare and validate the change, and draft this pull request. I reviewed the final content and verified the links.